### PR TITLE
Expose the declaration file

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
+  "types": "dist/index.d.ts",
   "devDependencies": {
     "@babel/cli": "^7.1.2",
     "@babel/core": "^7.1.2",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
   "scripts": {
     "test": "jest",
     "babel": "babel src --out-dir dist --ignore \"src/**/*.test.js,__snapthots__\"",
-    "prepublish": "rm -rf dist && npm run babel && mv dist/index.macro.js dist/index.js"
+    "prepublish": "rm -rf dist && npm run babel && mv dist/index.macro.js dist/index.js && cp src/index.d.ts dist/"
   },
   "jest": {
     "transform": {


### PR DESCRIPTION
Copy the declaration file from `src` to `dist` before publishing

The file will be available from the public package (`graphql-tag.macro/index.d.ts`)